### PR TITLE
prefix storage

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -2,7 +2,7 @@ name: Master Branch Unit Testing
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ master, develop ]
   push:
     branches: [ master, develop ]
 

--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -5,6 +5,7 @@ import { GuildMessage, PromiseVoid } from "./utils";
 import { CommandStorage } from "./command/Storage";
 import { CommandContext } from "./command/Context";
 import { readFileSync, PathLike } from "fs";
+import { BotPrefixes } from "./BotPrefixes";
 
 /**
  * Обёртка клиента API из discord.js
@@ -31,12 +32,19 @@ export class Bot {
     public readonly commands = new CommandStorage();
 
     /**
+     * Префиксы бота
+     */
+    public readonly prefixes: BotPrefixes;
+
+    /**
      * @param options настройки клиента API discord.js
      */
-    constructor(options: BotOptionsArgument) {
+    constructor(options: BotOptionsArgument = {}) {
         this.client = new Client(options.clientOptions);
 
         this.options = ParseBotOptionsArgument(options);
+
+        this.prefixes = new BotPrefixes(this);
 
         this.client.on('ready', () => {
             console.log("logged in as " + String(this.client.user?.username));
@@ -58,15 +66,7 @@ export class Bot {
      * @param message сообщение пользователя
      */
     public async handleCommands(message: GuildMessage): Promise<void> {
-        let prefixLength = 0;
-        const msgLowerContent = message.content.toLowerCase();
-        for (const p of this.options.prefixes) {
-            if (msgLowerContent.startsWith(p)) {
-                prefixLength = p.length;
-                break;
-            }
-        }
-
+        const prefixLength = this.prefixes.getMessagePrefixLength(message);
         if (!prefixLength) {
             return;
         }

--- a/src/BotOptions.ts
+++ b/src/BotOptions.ts
@@ -5,10 +5,6 @@ import { ClientOptions } from "discord.js";
  */
 export type BotOptions = {
     /**
-     * Список префиксов бота
-     */
-    prefixes: string[];
-    /**
      * Настройки проверки прав
      */
     permissions: {
@@ -29,8 +25,7 @@ export type BotOptions = {
  * Аргумент настроек бота в его конструкторе
  * @ignore
  */
-export type BotOptionsArgument = Partial<Omit<BotOptions, 'prefixes'>> & {
-    prefixes: string[] | string;
+export type BotOptionsArgument = Partial<BotOptions> & {
     clientOptions?: ClientOptions;
 };
 
@@ -39,11 +34,6 @@ export type BotOptionsArgument = Partial<Omit<BotOptions, 'prefixes'>> & {
  * @ignore
  */
 export function ParseBotOptionsArgument(optionsArg: BotOptionsArgument): BotOptions {
-    let prefixes = optionsArg.prefixes;
-    if (typeof prefixes == 'string') {
-        prefixes = [ prefixes ];
-    }
-
     let permissions = optionsArg.permissions;
     if (!permissions) {
         permissions = {
@@ -52,7 +42,6 @@ export function ParseBotOptionsArgument(optionsArg: BotOptionsArgument): BotOpti
     }
 
     return {
-        prefixes,
         permissions,
         ignoreBots: optionsArg.ignoreBots ?? true,
     };

--- a/src/BotPrefixes.ts
+++ b/src/BotPrefixes.ts
@@ -1,0 +1,64 @@
+import { PrefixStorage } from './PrefixStorage';
+import { GuildMessage } from './utils';
+import { Guild } from 'discord.js';
+import { Bot } from './Bot';
+
+export class BotPrefixes {
+    /**
+     * Хранилище глобальных префиксов.
+     * Глобальные префиксы команд доступны на всех серверах
+     */
+    public readonly global = new PrefixStorage();
+
+    /**
+     * Стандартные префиксы для новых серверов
+     */
+    public readonly defaultGuild = new PrefixStorage(['!']);
+
+    #guildPrefixes = new Map<string, PrefixStorage>();
+
+    constructor(bot: Bot) {
+        bot.client.on('guildCreate', ({ id }) => {
+            this.#guildPrefixes.set(id, new PrefixStorage(this.defaultGuild));
+        });
+
+        bot.client.on('guildDelete', ({ id }) => {
+            this.#guildPrefixes.delete(id);
+        });
+
+        bot.client.on('ready', () => {
+            for (const { id } of bot.client.guilds.cache.values()) {
+                this.#guildPrefixes.set(id, new PrefixStorage(this.defaultGuild));
+            }
+        });
+    }
+
+    /**
+     * @param guild сервер
+     * @param create создать ли хранилище, если его нет
+     * @returns хранилище префиксов сервера
+     */
+    public guild(guild: Guild, create: boolean = false): PrefixStorage {
+        const { id } = guild;
+        let storage = this.#guildPrefixes.get(id);
+        if (!storage) {
+            if (create) {
+                storage = new PrefixStorage(this.defaultGuild);
+                this.#guildPrefixes.set(id, storage);
+            }
+            throw new Error(`unknown guild with id '${id}'`);
+        }
+        return storage;
+    }
+
+    public getMessagePrefixLength(message: GuildMessage): number {
+        const msgLower = message.content.toLowerCase();
+        const prefixes = this.global.list.concat(this.guild(message.guild).list);
+        for (const prefix of prefixes) {
+            if (msgLower.startsWith(prefix)) {
+                return prefix.length;
+            }
+        }
+        return 0;
+    }
+}

--- a/src/BotPrefixes.ts
+++ b/src/BotPrefixes.ts
@@ -7,8 +7,9 @@ export class BotPrefixes {
     /**
      * Хранилище глобальных префиксов.
      * Глобальные префиксы команд доступны на всех серверах
+     * @default PrefixStorage(['!'])
      */
-    public readonly global = new PrefixStorage();
+    public readonly global = new PrefixStorage(['!']);
 
     /**
      * Стандартные префиксы для новых серверов
@@ -51,10 +52,22 @@ export class BotPrefixes {
         return storage;
     }
 
+    private *getPrefixesToCheck(message: GuildMessage): IterableIterator<string> {
+        const seen: Record<string, true> = {};
+        for (const prefix of this.guild(message.guild)) {
+            yield prefix;
+            seen[prefix] = true;
+        }
+        for (const prefix of this.global) {
+            if (!seen[prefix]) {
+                yield prefix;
+            }
+        }
+    }
+
     public getMessagePrefixLength(message: GuildMessage): number {
         const msgLower = message.content.toLowerCase();
-        const prefixes = this.global.list.concat(this.guild(message.guild).list);
-        for (const prefix of prefixes) {
+        for (const prefix of this.getPrefixesToCheck(message)) {
             if (msgLower.startsWith(prefix)) {
                 return prefix.length;
             }

--- a/src/PrefixStorage.ts
+++ b/src/PrefixStorage.ts
@@ -1,13 +1,15 @@
+import { ReadOnlyNonEmptyArray } from "./utils";
+
 /**
  * Хранилище префиксов команд
  */
-export class PrefixStorage {
+export class PrefixStorage implements Iterable<string> {
     #prefixes: Set<string>;
 
     /**
      * @param initialPrefixes изначальные префиксы в хранилище
      */
-    constructor(initialPrefixes: ReadonlyArray<string> | PrefixStorage = []) {
+    constructor(initialPrefixes: ReadOnlyNonEmptyArray<string> | PrefixStorage) {
         this.#prefixes = new Set();
         if (initialPrefixes instanceof PrefixStorage) {
             initialPrefixes = initialPrefixes.list;
@@ -19,14 +21,18 @@ export class PrefixStorage {
      * Свойство, возвращающее список префиксов в хранилище.
      * Список доступен только для чтения
      */
-    get list(): ReadonlyArray<string> {
-        return [...this.#prefixes];
+    get list(): ReadOnlyNonEmptyArray<string> {
+        return [...this.#prefixes] as any;
+    }
+
+    public [Symbol.iterator](): IterableIterator<string> {
+        return this.#prefixes.values();
     }
 
     /**
      * Количество префиксов в хранилище
      */
-    get length(): number {
+    get size(): number {
         return this.#prefixes.size;
     }
 
@@ -46,12 +52,12 @@ export class PrefixStorage {
     }
 
     /**
-     * Удаляет префикс из хранилища
+     * Удаляет префикс из хранилища (если он не единственный)
      * @param prefix префикс, который нужно удалить
      * @returns true, если префикс был удалён
      */
     remove(prefix: string): boolean {
-        return this.#prefixes.delete(prefix.toLowerCase());
+        return this.size > 1 ? this.#prefixes.delete(prefix.toLowerCase()) : false;
     }
 
     /**
@@ -69,5 +75,9 @@ export class PrefixStorage {
     set(prefix: string) {
         this.#prefixes.clear();
         this.#prefixes.add(prefix.toLowerCase());
+    }
+
+    public toString(): string {
+        return `${PrefixStorage.name}(${this.size}) { ${this.list.join(', ')} }`;
     }
 }

--- a/src/PrefixStorage.ts
+++ b/src/PrefixStorage.ts
@@ -1,0 +1,73 @@
+/**
+ * Хранилище префиксов команд
+ */
+export class PrefixStorage {
+    #prefixes: Set<string>;
+
+    /**
+     * @param initialPrefixes изначальные префиксы в хранилище
+     */
+    constructor(initialPrefixes: ReadonlyArray<string> | PrefixStorage = []) {
+        this.#prefixes = new Set();
+        if (initialPrefixes instanceof PrefixStorage) {
+            initialPrefixes = initialPrefixes.list;
+        }
+        initialPrefixes.forEach(prefix => this.add(prefix));
+    }
+
+    /**
+     * Свойство, возвращающее список префиксов в хранилище.
+     * Список доступен только для чтения
+     */
+    get list(): ReadonlyArray<string> {
+        return [...this.#prefixes];
+    }
+
+    /**
+     * Количество префиксов в хранилище
+     */
+    get length(): number {
+        return this.#prefixes.size;
+    }
+
+    /**
+     * Добавляет префикс в хранилище
+     * @param prefix новый префикс
+     * @returns true, если этого префикса раньше не было в хранилище
+     */
+    add(prefix: string): boolean {
+        prefix = prefix.toLowerCase();
+        if (!prefix || prefix.includes(' ')) {
+            throw new Error(`invalid prefix '${prefix}'`);
+        }
+        const was = this.#prefixes.has(prefix);
+        this.#prefixes.add(prefix);
+        return !was;
+    }
+
+    /**
+     * Удаляет префикс из хранилища
+     * @param prefix префикс, который нужно удалить
+     * @returns true, если префикс был удалён
+     */
+    remove(prefix: string): boolean {
+        return this.#prefixes.delete(prefix.toLowerCase());
+    }
+
+    /**
+     * @param prefix префикс для проверки
+     * @returns true, если префикс есть в хранилище
+     */
+    has(prefix: string): boolean {
+        return this.#prefixes.has(prefix.toLowerCase());
+    }
+
+    /**
+     * Устанавливает единственный префикс в хранилище
+     * @param prefix единственный префикс хранилища
+     */
+    set(prefix: string) {
+        this.#prefixes.clear();
+        this.#prefixes.add(prefix.toLowerCase());
+    }
+}

--- a/src/PrefixStorage.ts
+++ b/src/PrefixStorage.ts
@@ -1,4 +1,4 @@
-import { ReadOnlyNonEmptyArray } from "./utils";
+import { ReadOnlyNonEmptyArray, NonEmptyArray } from "./utils";
 
 /**
  * Хранилище префиксов команд
@@ -69,12 +69,19 @@ export class PrefixStorage implements Iterable<string> {
     }
 
     /**
-     * Устанавливает единственный префикс в хранилище
-     * @param prefix единственный префикс хранилища
+     * Ставит список префиксов в хранилище
+     * @param prefixes
      */
-    set(prefix: string) {
+    set(...prefixes: NonEmptyArray<string>) {
+        const old = new Set(this.#prefixes);
         this.#prefixes.clear();
-        this.#prefixes.add(prefix.toLowerCase());
+        try {
+            prefixes.forEach(prefix => this.add(prefix));
+        }
+        catch (err) {
+            this.#prefixes = old;
+            throw err;
+        }
     }
 
     public toString(): string {

--- a/src/command/argument/Readers.ts
+++ b/src/command/argument/Readers.ts
@@ -145,7 +145,7 @@ export const MakeMentionReader = <T>(
 /**
  * Читает упоминание участника сервера
  */
-export const ReadMember = MakeMentionReader('<@\\!?\\d+>', (msg, id) => msg.guild.member(id));
+export const ReadMember = MakeMentionReader('<@!?\\d+>', (msg, id) => msg.guild.member(id));
 
 /**
  * Читает упоминание роли

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,5 +7,8 @@ export { CommandInfo, CommandExecuteable, Command } from './command/Info';
 export { CommandStorage } from './command/Storage';
 export { CommandContext } from './command/Context';
 
+export { PrefixStorage } from './PrefixStorage';
+export { BotPrefixes } from './BotPrefixes';
+
 export { BotOptions } from './BotOptions';
 export { Bot } from './Bot';

--- a/src/tests/PrefixStorage.test.ts
+++ b/src/tests/PrefixStorage.test.ts
@@ -1,0 +1,81 @@
+import { PrefixStorage } from "../PrefixStorage";
+
+describe('invalid prefix', () => {
+    test('initial test', () => {
+        expect(() => new PrefixStorage(['abc test'])).toThrowError("invalid prefix 'abc test'");
+        expect(() => new PrefixStorage([''])).toThrowError("invalid prefix ''");
+    });
+
+    const prefixes = new PrefixStorage(['!', '&']);
+
+    test('space', () => {
+        expect(() => prefixes.add('o e')).toThrowError("invalid prefix 'o e'");
+    });
+
+    test('empty', () => {
+        expect(() => prefixes.add('')).toThrowError("invalid prefix ''");
+    });
+});
+
+describe('edit', () => {
+    const prefixes = new PrefixStorage(['!']);
+
+    test('add return value', () => {
+        expect(prefixes.add('new.')).toBe(true);
+        expect(prefixes.add('!')).toBe(false);
+    });
+
+    test('add', () => {
+        expect(prefixes.list).toEqual(['!', 'new.']);
+        expect(prefixes.size).toBe(2);
+        prefixes.add('old.');
+        expect(prefixes.list).toEqual(['!', 'new.', 'old.']);
+        expect(prefixes.size).toBe(3);
+    });
+
+    test('remove', () => {
+        expect(prefixes.size).toBe(3);
+        expect(prefixes.list).toEqual(['!', 'new.', 'old.']);
+        prefixes.remove('old.');
+        expect(prefixes.list).toEqual(['!', 'new.']);
+        expect(prefixes.size).toBe(2);
+    });
+
+    test('has', () => {
+        expect(prefixes.has('!')).toBe(true);
+        expect(prefixes.has('random')).toBe(false);
+    });
+
+    describe('invalid prefix remove safe', () => {
+        test('space', () => {
+            expect(() => prefixes.remove('a b')).not.toThrowError("invalid prefix 'a b'");
+        });
+
+        test('empty', () => {
+            expect(() => prefixes.remove('')).not.toThrowError("invalid prefix ''");
+        });
+    });
+
+    test('set', () => {
+        prefixes.set('!');
+        expect(prefixes.size).toBe(1);
+        expect(prefixes.list).toEqual(['!']);
+    });
+
+    test('remove before empty', () => {
+        expect(prefixes.remove('!')).toBe(false);
+        expect(prefixes.size).not.toBe(0);
+        expect(prefixes.list).not.toEqual([]);
+    });
+});
+
+test('iterable', () => {
+    const prefixes = new PrefixStorage(['~', '!']);
+    const p: string[] = [];
+    for (const prefix of prefixes) {
+        p.push(prefix);
+    }
+    expect(p).toContain('~');
+    expect(p).toContain('!');
+    expect(p.length).toBe(2);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
         "target": "ES6",
         "module": "commonjs",
         "outDir": "dist",
+        "incremental": true,
         "moduleResolution": "node",
         "removeComments": false,
         "skipLibCheck": true,


### PR DESCRIPTION
Добавлен класс хранилища префиксов `PrefixStorage`. Работает как `Set` из js с проверками строк (префикс не может содержать пробелы, не может быть пустой строкой)

У бота появилось свойство `prefixes`. В нём есть хранилище глобальных префиксов (глобальные префиксы доступны на всех серверах), а также функция для получения префиксов сервера

Все упоминания префиксов в `BotOptions` удалены за ненадобностью