### PR TITLE
Система синтаксиса команд

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ bot.loginFromFile('./token.txt');
 
 #### Сложение двух чисел
 
+Ручное чтение аргументов:
 ```js
 bot.commands.register('sum', ({ message, read: { number } }) => {
     const [a, b] = [number(), number()];
@@ -47,25 +48,31 @@ bot.commands.register('sum', ({ message, read: { number } }) => {
 });
 ```
 
+Чтение аргументов через `синтаксис`:
+```js
+bot.commands.register('sum', {
+    syntax: '<number:first> <number:second>',
+    execute: ({ message, args: { first, second } }) => {
+        message.reply(first + second);
+    },
+});
+```
+
 #### Ban
 
 ```js
-bot.commands.register('ban', async ({ message, read: { member, remainingText }, isEOL }) => {
-    const target = member();
-    if (message.member.id == target.id) {
-        throw new Error('Нельзя забанить самого себя!');
-    }
-    if (!target.bannable) {
-        throw new Error('Я не могу забанить этого участника сервера :/');
-    }
-
-    let reason = 'Злобные админы :/';
-    if (!isEOL()) { // есть ли ещё аргументы в сообщении
-        reason = remainingText();
-    }
-
-    await target.ban({ reason });
-    await message.reply(`**${target.displayName}** успешно сослан в Сибирь`);
+bot.commands.register('ban', {
+    syntax: '<member:target> <remainingText:reason=Злобные админы :/>',
+    execute: async ({ message, executor, args: { target, reason } }) => {
+        if (executor.id == target.id) {
+            throw new Error('Нельзя забанить самого себя!');
+        }
+        if (!target.bannable) {
+            throw new Error('Я не могу забанить этого участника сервера :/');
+        }
+        await target.ban({ reason });
+        await message.reply(`**${target.displayName}** успешно сослан в Сибирь`);
+    },
 });
 ```
 
@@ -80,6 +87,8 @@ bot.commands.register('ban', {
 
     description: 'Банит участника сервера',
     group: 'Администрирование',
+
+    syntax: '<member:target> <remainingText:reason>',
     examples: [
         '`ban @Test` забанит участника @Test',
         '`ban @Test спам` забанит @Test по причине "спам"',
@@ -108,7 +117,7 @@ bot.client.on('событие discord.js', () => {
 * `role` - упоминание роли на сервере
 * `textChannel` - упоминание текстового канала
 * `remainingText` - оставшийся текст команды
-* `word` - слово (последовательность символов без пробел)
+* `word` - слово (последовательность символов до пробела)
 
 ### Встроенные команды
 

--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -31,7 +31,7 @@ export class Bot {
     /**
      * Хранилище команд бота
      */
-    public readonly commands = new CommandStorage();
+    public readonly commands: CommandStorage;
 
     /**
      * Префиксы бота
@@ -45,6 +45,8 @@ export class Bot {
         this.client = new Client(options.clientOptions);
 
         this.options = ParseBotOptionsArgument(options);
+
+        this.commands = new CommandStorage(this.commandArguments);
 
         this.prefixes = new BotPrefixes(this);
 
@@ -101,7 +103,7 @@ export class Bot {
                 throw new Error(`Not enough permissions: ${missingPermissions.join(', ')}`);
             }
 
-            const context = new CommandContext(this, message as GuildMessage, executor);
+            const context = new CommandContext(command, this, message as GuildMessage, executor);
             await command.execute(context);
         });
     }

--- a/src/command/Context.ts
+++ b/src/command/Context.ts
@@ -80,4 +80,17 @@ export class CommandContext {
 
         return parsedValue as T;
     }
+    
+    private readSyntax(syntax: string): any {
+        const argDefs = syntax.replace(/\s{2,}/, ' ').split(' ');
+        
+        type ArgData = { name: string; reader: ArgumentReader<T> };
+        const args: ArgData[] = [];
+        
+        const dataRegex = /(?<type>\w+):(?<name>\w+)/;
+        const typeRegex = /(<(?<data>.+)>)|(\[(?<data>.+)\])/;
+        for (const def of argDefs) {
+            // TODO
+        }
+    }
 }

--- a/src/command/Info.ts
+++ b/src/command/Info.ts
@@ -2,6 +2,12 @@ import { ReadOnlyNonEmptyArray, PromiseVoid } from "../utils";
 import { PermissionString } from "discord.js";
 import { CommandContext } from "./Context";
 
+export type CommandArgumentData = {
+    name: string;
+    type: string;
+    readDefault?: (context: CommandContext) => any;
+};
+
 /**
  * Информация о команде
  */
@@ -28,8 +34,17 @@ export interface CommandInfo {
     
     /**
      * Синтаксис
+     * Пример: !ban `<member:target> <remainingText:reason=спам>`
      */
     readonly syntax?: string;
+
+    /**
+     * Аргументы команды.
+     * Если это свойство указано, то в [[Command.execute]] из контекста будет доступно
+     * свойство [[CommandContext.args]].
+     * Это свойство заполняется автоматически, если указано свойство [[CommandInfo.syntax]]
+     */
+    readonly arguments?: CommandArgumentData[];
 
     /**
      * Примеры использования

--- a/src/command/Info.ts
+++ b/src/command/Info.ts
@@ -25,6 +25,11 @@ export interface CommandInfo {
      * Описание
      */
     readonly description?: string;
+    
+    /**
+     * Синтаксис
+     */
+    readonly syntax?: string;
 
     /**
      * Примеры использования
@@ -45,4 +50,6 @@ export type CommandExecuteable = (context: CommandContext) => PromiseVoid;
 /**
  * Функция запуска команды вместе с её информацией
  */
-export type Command = CommandInfo & { execute: CommandExecuteable };
+export interface Command extends CommandInfo {
+    execute: CommandExecuteable;
+}

--- a/src/command/builtIn/Ban.ts
+++ b/src/command/builtIn/Ban.ts
@@ -1,7 +1,5 @@
 import { Command } from "../Info";
 
-const defaultReason = 'Злобные админы :/';
-
 export default {
     name: 'ban',
 
@@ -9,22 +7,20 @@ export default {
 
     description: 'Банит участника сервера',
     group: 'Администрирование',
+
+    syntax: '<member:target> <remainingText:reason=Злобные админы :/>',
     examples: [
         '`ban @Test` забанит участника @Test по причине ',
         '`ban @Test спам` забанит @Test по причине "спам"',
     ],
 
-    execute: async ({ message, executor, read: { member, remainingText }, isEOL }) => {
-        const target = member();
-
+    execute: async ({ message, executor, args: { target, reason } }) => {
         if (executor.id == target.id) {
             throw new Error('Нельзя забанить самого себя!');
         }
         if (!target.bannable) {
             throw new Error('Я не могу забанить этого участника сервера :/');
         }
-
-        const reason = isEOL() ? defaultReason : remainingText();
 
         await target.ban({ reason });
         await message.reply(`**${target.displayName}** успешно забанен`);

--- a/src/command/builtIn/Help.ts
+++ b/src/command/builtIn/Help.ts
@@ -38,6 +38,10 @@ function makeCommandInfo(embed: MessageEmbed, command: Command) {
 
     embed.addField('Описание', command.description || '*Отсутствует*');
 
+    if (command.syntax) {
+        embed.addField('Синтаксис', `\`${command.syntax}\``);
+    }
+
     if (command.examples) {
         embed.addField('Примеры использования', command.examples.map(e => '- ' + e).join('\n'));
     }
@@ -52,15 +56,16 @@ export default {
 
     description: 'Помощь по командам бота',
     group: 'Информация',
+
+    syntax: '<word:commandName=_>',
     examples: [
         '`!help` даст список команд',
         '`!help test` даст информацию о команде `test`'
     ],
 
-    execute: ({ message, read: { remainingText }, isEOL, bot: { commands } }) => {
+    execute: ({ message, bot: { commands }, args: { commandName } }) => {
         const embed = new MessageEmbed().setColor(0x45ff83);
 
-        const commandName = isEOL() ? '' : remainingText();
         if (!commandName) {
             makeCommandsList(embed, message.member, commands);
         }

--- a/src/command/builtIn/Kick.ts
+++ b/src/command/builtIn/Kick.ts
@@ -1,7 +1,5 @@
 import { Command } from "../Info";
 
-const defaultReason = 'Злобные админы :/';
-
 export default {
     name: 'kick',
 
@@ -9,22 +7,20 @@ export default {
 
     description: 'Кикает участника сервера',
     group: 'Администрирование',
+
+    syntax: '<member:target> <remainingText:reason=Злобные админы :/>',
     examples: [
         '`kick @Test` кикнет участника @Test по причине ',
         '`kick @Test спам` кикнет @Test по причине "спам"',
     ],
 
-    execute: async ({ message, executor, read: { member, remainingText }, isEOL }) => {
-        const target = member();
-
+    execute: async ({ message, executor, args: { target, reason } }) => {
         if (executor.id == target.id) {
             throw new Error('Нельзя кикнуть самого себя!');
         }
         if (!target.kickable) {
             throw new Error('Я не могу кикнуть этого участника сервера :/');
         }
-
-        const reason = isEOL() ? defaultReason : remainingText();
 
         await target.kick(reason);
         await message.reply(`**${target.displayName}** успешно сослан в Сибирь`);

--- a/src/command/builtIn/Prefix.ts
+++ b/src/command/builtIn/Prefix.ts
@@ -6,40 +6,39 @@ export default {
     description: 'Команда управления префиксами на сервере',
     group: 'Настройки',
     permissions: ['MANAGE_GUILD'],
+
+    syntax: '<word:operation=_> <word:prefix=_>',
     examples: [
         '`!prefix` даст список префиксов бота на сервере',
         '`!prefix add ~` добавит `~` в список префиксов бота',
         '`!prefix rm ~` удалит `~` из списка префиксов бота',
     ],
 
-    execute: ({ message, executor, bot, read: { member, word }, isEOL }) => {
+    execute: ({ message, bot, args: { command: operation, prefix } }) => {
         const prefixes = bot.prefixes.guild(message.guild);
 
-        if (isEOL()) {
+        if (!operation) {
             const strList = prefixes.list.map(p => `\`${p}\``).join(', ');
             message.reply(`список моих префиксов на этом сервере: ${strList}`);
             return
         }
 
-        const operation = word();
         switch (operation) {
             default: throw new Error(`unsupported prefix operation '${operation}'`);
             case 'add':
-                const newPref = word();
-                if (prefixes.add(newPref)) {
-                    message.reply(`новый префикс команд: \`${newPref}\``);
+                if (prefixes.add(prefix)) {
+                    message.reply(`новый префикс команд: \`${prefix}\``);
                 }
                 else {
                     message.reply(`невозможно добавить такой префикс`);
                 }
                 break;
             case 'rm':
-                const oldPref = word();
-                if (prefixes.remove(oldPref)) {
-                    message.reply(`префикс \`${oldPref}\` успешно удалён из списка`);
+                if (prefixes.remove(prefix)) {
+                    message.reply(`префикс \`${prefix}\` успешно удалён из списка`);
                 }
                 else {
-                    message.reply(`невозможно удалить префикс \`${oldPref}\``);
+                    message.reply(`невозможно удалить префикс \`${prefix}\``);
                 }
                 break;
         }

--- a/src/tests/CommandStorage.test.ts
+++ b/src/tests/CommandStorage.test.ts
@@ -1,11 +1,14 @@
 import { CommandExecuteable, Command } from '../command/Info';
 import { CommandStorage } from '../command/Storage';
 import { NonEmptyArray } from '../utils';
+import { ArgumentReaderStorage } from '../command/argument/Storage';
 
 const emptyCommand: CommandExecuteable = () => {};
 
+const argumentReaders = new ArgumentReaderStorage();
+
 describe('name tests', () => {
-    const commands = new CommandStorage();
+    const commands = new CommandStorage(argumentReaders);
 
     test('space', () => {
         const name = 'test b';
@@ -23,7 +26,7 @@ describe('name tests', () => {
 });
 
 describe('get by name test', () => {
-    const commands = new CommandStorage();
+    const commands = new CommandStorage(argumentReaders);
 
     const aliases: NonEmptyArray<string> = ['main2', 'second', 'wow', 'test'];
 
@@ -77,7 +80,7 @@ describe('get by name test', () => {
 });
 
 describe('commands list tests', () => {
-    const commands = new CommandStorage();
+    const commands = new CommandStorage(argumentReaders);
 
     test('empty', () => {
         let commandsList = commands.list;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,9 @@
         "skipLibCheck": true,
         "declaration": true,
         "declarationDir": "types",
+        "lib": [
+            "es2020.string",
+        ],
     },
     "include": [
         "src",


### PR DESCRIPTION
Добавлена система синтаксиса команд

С её помощью для чтения аргументов пользователь может указать параметр `syntax`

```js
bot.commands.register('math', {
    syntax: '<number:first> <number:second>',
    execute: ({ args: { first, second } }) => {
        // логика
    },
});
```

Внутри функции `register` библиотека 'интерпретирует' синтаксис в список аргументов `arguments`

Дальше данные из `arguments` использует класс `ComandContext` -> автоматически читает указанные аргументы и записывает результаты в своё свойство `args`

Соответственно прошлая запись идентична этой записи:
```js
bot.commands.register('math', {
    arguments: [
        { type: 'number', name: 'first' },
        { type: 'number', name: 'second'},
    ],
    execute: ({ args: { first, second } }) => {
        // логика
    },
});
```

Также в синтаксисе можно указать стандартное значение аргумента:
`<number:third=0>`

Вместо значения можно указать `_`. Тогда, если пользователь не введёт этот аргумент, в `args` у него будет значение `undefined`
