### PR TITLE
Command.requiredProperties

### DIFF
--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -83,9 +83,16 @@ export class Bot extends EventEmitter {
         });
 
         this.database.definedProperties.add(this.prefixesProperty);
+
         for (const property of this.options.database.definedProperties) {
             this.database.definedProperties.add(property);
         }
+
+        this.commands.on('added', command => {
+            command.requiredProperties?.forEach(property => {
+                this.database.definedProperties.add(property);
+            });
+        });
 
         this.client.once('ready', () => {
             this.database.load();

--- a/src/command/Command.ts
+++ b/src/command/Command.ts
@@ -1,5 +1,6 @@
 import { BitFieldResolvable, Permissions, PermissionString } from "discord.js";
 import { Bot } from "../Bot";
+import { AnyProperty } from "../database/property/Property";
 import { GuildMessage, NonEmptyReadonly, Overwrite, PromiseVoid } from "../utils";
 import { CommandArgumentsReader } from "./argument/Reader";
 import { CommandContext } from "./Context";
@@ -43,6 +44,11 @@ export interface CommandInfo<Args extends unknown[]> {
      * Примеры использования
      */
     readonly examples?: NonEmptyReadonly<string[]>;
+
+    /**
+     * Свойства сущностей в базе данных, с которыми работает команда
+     */
+    readonly requiredProperties?: NonEmptyReadonly<AnyProperty[]>;
 }
 
 /**

--- a/src/command/Storage.ts
+++ b/src/command/Storage.ts
@@ -1,11 +1,17 @@
+import { EventEmitter } from "events";
 import { PathLike, readdirSync } from "fs";
 import { join } from "path";
+import { TypedEventEmitter } from "../utils";
 import { AnyCommand, Command } from "./Command";
+
+interface CommandStorageEvents {
+    added(command: AnyCommand): void;
+}
 
 /**
  * Хранилище команд
  */
-export class CommandStorage implements Iterable<AnyCommand> {
+export class CommandStorage extends (EventEmitter as new () => TypedEventEmitter<CommandStorageEvents>) implements Iterable<AnyCommand> {
     /**
      * Map команд по их именам
      */
@@ -34,6 +40,8 @@ export class CommandStorage implements Iterable<AnyCommand> {
             assertNameCollision(alias);
             this.aliasMap.set(alias, command);
         });
+
+        this.emit('added', command);
     }
 
     /**

--- a/src/database/BotDatabase.ts
+++ b/src/database/BotDatabase.ts
@@ -66,7 +66,9 @@ export class BotDatabase extends EventEmitter {
      * @param property свойство сущности
      */
     public accessProperty<E extends EntityType, T, A extends PropertyAccess<T>>(entity: Entity<E>, property: Property<E, T, A>): A {
-        this.definedProperties.add(property);
+        if (!this.definedProperties.has(property.key)) {
+            throw new Error(`can't acces undefined ${property.entityType} property with key '${property.key}'`);
+        }
 
         type ValueStorage = DatabaseValueStorage<E>;
         let storage: ValueStorage | undefined = undefined;

--- a/src/database/property/DefinitionStorage.ts
+++ b/src/database/property/DefinitionStorage.ts
@@ -1,6 +1,9 @@
 import { EntityType } from "../Entity";
 import { AnyProperty } from "./Property";
 
+/**
+ * Хранилище свойств сущностей в базе данных
+ */
 export class PropertyDefinitionStorage {
     #properties = new Map<string, AnyProperty>();
 
@@ -16,6 +19,14 @@ export class PropertyDefinitionStorage {
 
         this.#properties.set(property.key, property);
         return true;
+    }
+
+    /**
+     * @returns true, если в хранилище есть свойство с ключом key
+     * @param key ключ свойства
+     */
+    has(key: string): boolean {
+        return this.#properties.has(key);
     }
 
     /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,4 @@
 import type { Guild, GuildMember, Message, TextChannel } from "discord.js";
-import { EventEmitter } from "events";
 
 /**
  * Сообщение в текстовом канале на сервере

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import type { Guild, GuildMember, Message, TextChannel } from "discord.js";
+import { EventEmitter } from "events";
 
 /**
  * Сообщение в текстовом канале на сервере
@@ -84,6 +85,33 @@ export type WidenLiteral<T> = T extends string ? string
  * Используется для того, чтобы TypeScript определял generic как литерал
  */
 export type InferPrimitive<T> = T extends Primitive ? T : WidenLiteral<T>;
+
+type EventArguments<T> = [T] extends [(...args: infer U) => any] ? U
+    : [T] extends [void] ? [] : [T]
+
+/**
+ * Типизированный обработчик событий
+ */
+export interface TypedEventEmitter<Events> {
+    addListener<E extends keyof Events>(event: E, listener: Events[E]): this;
+    on<E extends keyof Events>(event: E, listener: Events[E]): this;
+    once<E extends keyof Events>(event: E, listener: Events[E]): this;
+    prependListener<E extends keyof Events>(event: E, listener: Events[E]): this;
+    prependOnceListener<E extends keyof Events>(event: E, listener: Events[E]): this;
+
+    off<E extends keyof Events>(event: E, listener: Events[E]): this;
+    removeAllListeners<E extends keyof Events>(event?: E): this;
+    removeListener<E extends keyof Events>(event: E, listener: Events[E]): this;
+
+    emit<E extends keyof Events>(event: E, ...args: EventArguments<Events[E]>): boolean;
+    eventNames(): (keyof Events | string | symbol)[];
+    rawListeners<E extends keyof Events>(event: E): Function[];
+    listeners<E extends keyof Events>(event: E): Function[];
+    listenerCount<E extends keyof Events>(event: E): number;
+
+    getMaxListeners(): number;
+    setMaxListeners(maxListeners: number): this;
+}
 
 /**
  * Является ли объект литералом (скорее всего)


### PR DESCRIPTION
Добавлять свойства через настройки не очень удобно. Особенно, когда это свойство используется только в паре команд

Теперь у команды есть поле `requiredProperties`. Когда в хранилище команд добавляется новая команда, библиотека добавляет указанные свойства в кэш

`accessProperty` кидает исключение, если пользователь пытается получить доступ к ранее не объявленному свойству
